### PR TITLE
[MONAI] Update --pretrain, --lr

### DIFF
--- a/research/lamp-automated-model-parallelism/README.md
+++ b/research/lamp-automated-model-parallelism/README.md
@@ -21,12 +21,20 @@ MICCAI 2020 (Early Accept, paper link: https://arxiv.org/abs/2006.12575)
 - `pip install torchgpipe`
 
 ### Data
+```bash
+    mkdir ./data;
+    cd ./data;
+```
 Head and Neck CT dataset
-please download and unzip the images into `./data` folder.
+
+Please download and unzip the images into `./data` folder.
 
 - `HaN.zip`: https://drive.google.com/file/d/1A2zpVlR3CkvtkJPvtAF3-MH0nr1WZ2Mn/view?usp=sharing
+```bash
+    unzip HaN.zip;  # unzip
+```
 
-Please find more details at https://github.com/wentaozhu/AnatomyNet-for-anatomical-segmentation.git
+Please find more details of the dataset at https://github.com/wentaozhu/AnatomyNet-for-anatomical-segmentation.git
 
 
 ### Hardware
@@ -39,7 +47,7 @@ Please find more details at https://github.com/wentaozhu/AnatomyNet-for-anatomic
 The number of features in the first block (`--n_feat`) can be 32, 64, or 128.
 ```bash
     mkdir ./log;
-    python train.py --n_feat=128 --crop_size='64,64,64' --bs=16 --ep=4800 > ./log/YOURLOG.log
-    python train.py --n_feat=128 --crop_size='128,128,128' --bs=4 --ep=1200 --pretrain='./HaN_64,64,64' > ./log/YOURLOG.log
-    python train.py --n_feat=128 --crop_size='-1,-1,-1' --bs=1 --ep=300 --pretrain='./HaN_128,128,128' > ./log/YOURLOG.log
+    python train.py --n_feat=128 --crop_size='64,64,64' --bs=16 --ep=4800 --lr=0.001 > ./log/YOURLOG.log
+    python train.py --n_feat=128 --crop_size='128,128,128' --bs=4 --ep=1200 --lr=0.001 --pretrain='./HaN_32_16_1200_[64, 64, 64]_0.001_*' > ./log/YOURLOG.log
+    python train.py --n_feat=128 --crop_size='-1,-1,-1' --bs=1 --ep=300 --lr=0.001 --pretrain='./HaN_32_16_1200_[64, 64, 64]_0.001_*' > ./log/YOURLOG.log
 ```


### PR DESCRIPTION
+ lr from 5e-4 to 1e-3 because we use mean for class channel instead of sum for class channel.
+ pretrain path is consistent with current model_name.

Fixes # .

### Description
A few sentences describing the changes proposed in this pull request.

### Status
**Ready/Work in progress/Hold**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or new feature that would cause existing functionality to change)
- [ ] New tests added to cover the changes
- [ ] Docstrings/Documentation updated
